### PR TITLE
Bump minimum HA version to 2026.3.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Meteo IMGW-PIB",
-    "homeassistant": "2026.2.0b0",
+    "homeassistant": "2026.3.0",
     "zip_release": true,
     "filename": "meteo_imgw_pib.zip",
     "country": "PL"


### PR DESCRIPTION
Closes https://github.com/bieniu/ha-meteo-imgw-pib/issues/250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Home Assistant version compatibility requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->